### PR TITLE
Now compiles on 1.9.0-nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trace"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Gulshan Singh <gsingh2011@gmail.com>"]
 repository = "https://github.com/gsingh93/trace"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trace"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Gulshan Singh <gsingh2011@gmail.com>"]
 repository = "https://github.com/gsingh93/trace"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trace"
-version = "0.1.4"
+version = "0.1.2"
 authors = ["Gulshan Singh <gsingh2011@gmail.com>"]
 repository = "https://github.com/gsingh93/trace"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,7 +284,7 @@ fn arg_idents(cx: &mut ExtCtxt, decl: &FnDecl) -> Vec<Ident> {
             &PatKind::Box(ref p) | &PatKind::Ref(ref p, _) => extract_idents(cx, &p.node, idents),
             &PatKind::Mac(ref m) => {
                 let sp = m.node.path.span;
-                cx.span_err(sp, "trace does not work on functions with macros in the arg list");
+                cx.span_warn(sp, "trace ignores pattern macros in function arguments");
             }
         }
     }


### PR DESCRIPTION
I updated a lot of small stuff so that `trace` compiles on the newest nightly.

I also added a feature in a separate commit that throws an error whenever trace is used on a function with a pattern macro in the arg list. Take the following program for example:

```rust
macro_rules! tuple_args {
    ($x:ident, $y:ident) => (
        ($x,$y)
    )
}

fn foo(tuple_args!(a,b): (u32, u32)) {
    println!("{}", a);
}

fn main() {
    foo((1,2)); // Prints "1"
}
```
This might be a regression, depending on how you look at it. If you want me to remove this "feature", let me know.