### PR TITLE
Hotfix for public functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ fn trace_expand(cx: &mut ExtCtxt,
                 Fn(..) => {
                     let new_item = expand_function(cx, options, &item, true);
                     cx.item(item.span, item.ident, item.attrs.clone(), new_item)
+                        .map(|mut it| { it.vis = item.vis.clone(); it })
                 }
                 Mod(ref m) => {
                     let new_items = expand_mod(cx, m, options);


### PR DESCRIPTION
This fixes the return value of [`syntax::ext::build::AstBuilder::item()` trait method implementation for `ExtCtxt`](https://github.com/rust-lang/rust/blob/master/src/libsyntax/ext/build.rs#L981) which doesn't respect visibility of the old item and issue #8.