### PR TITLE
Switch to `proc-macro`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,29 @@
 language: rust
+sudo: false
+
 rust:
-  - nightly
+  - 1.30.0  # Minimum supported Rust
+  - stable
+  - beta
+
+script:
+  - cargo build --verbose
+  # Some examples require nightly, so let's delegate that to nightly builds
+  - cargo test --verbose --lib
+
+matrix:
+  include:
+    - rust: nightly
+      script:
+        - cargo build --verbose
+        - cargo test --verbose
+
+        - RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo build --verbose
+        - RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo test --verbose
+
+        - cargo update -Z minimal-versions
+        - cargo build --verbose
+        - cargo test --verbose
+
+        - RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo build --verbose
+        - RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,9 @@ license = "MIT"
 description = "A syntax extension for tracing the execution of functions"
 
 [lib]
-name = "trace"
-plugin = true
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "0.4.20"
+quote = "0.6.8"
+syn = { version = "0.15.10", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
-trace [![](https://meritbadge.herokuapp.com/trace)](https://crates.io/crates/trace) [![Build Status](https://travis-ci.org/gsingh93/trace.svg?branch=master)](https://travis-ci.org/gsingh93/trace)
+trace
+[![](https://meritbadge.herokuapp.com/trace)](https://crates.io/crates/trace)
+[![Build Status](https://travis-ci.org/gsingh93/trace.svg?branch=master)](https://travis-ci.org/gsingh93/trace)
 -----
 
-A syntax extension for tracing the execution of functions. Adding `#[trace]` to the top of any function will insert `println!` statements at the beginning and end of that function, notifying you of when that function was entered and exited and printing the argument and return values. This is useful for quickly debugging whether functions that are supposed to be called are actually called without manually inserting print statements.
+A procedural macro for tracing the execution of functions.
+Adding `#[trace]` to the top of any function will insert `println!` statements at the beginning and the end of that function, notifying you of when that function was entered and exited and printing the argument and return values.
+This is useful for quickly debugging whether functions that are supposed to be called are actually called without manually inserting print statements.
 
-Note that this extension requires all arguments to the function and the return value to have types that implement `Debug`. You can disable the printing of certain arguments if necessary (described below).
+Note that this macro requires all arguments to the function and the return value to have types that implement `Debug`. You can disable the printing of certain arguments if necessary (described below).
 
 ## Installation
 
@@ -14,9 +18,11 @@ Add `trace = "*"` to your `Cargo.toml`.
 Here is an example you can find in the examples folder. If you've cloned the project, you can run this with `cargo run --example example`.
 
 ```rust
-#![feature(custom_attribute, plugin)]
-#![plugin(trace)]
+extern crate trace;
 
+use trace::trace;
+
+#[allow(non_upper_case_globals)]
 static mut depth: u32 = 0;
 
 fn main() {
@@ -42,19 +48,26 @@ fn bar((a, b): (i32, i32)) -> i32 {
 
 Output:
 ```
-[+] Entering foo(a: 1, b: 2)
+[+] Entering foo(a = 1, b = 2)
 I'm in foo!
- [ENTER] Entering bar(a: 1, b: 2)
+ [ENTER] Entering bar(a = 1, b = 2)
 I'm in bar!
  [EXIT] Exiting bar = 2
 [-] Exiting foo = ()
 ```
 
-- Note the `depth` variable must be a global `static mut` variable, it's used for indenting the output. The only time it can be omitted is when `#[trace]` is applied to `mod`s, as described below.
+- Note the `depth` variable must be a global `static mut` variable, it's used for indenting the output.
+  The only time it can be omitted is when `#[trace]` is applied to `mod`s, as described below.
 
-- You can use `#[trace]` on `mod`s as well. To apply `#[trace]` to all functions in the current `mod`, put `#![trace]` (note the `!`) at the top of the file. When using `#[trace]` on `mod`s, the `depth` variable doesn't need to be defined (it's defined for you automatically). Note that the `depth` variable isn't shared between `mod`s, so indentation won't be perfect when tracing functions in multiple `mod`s.
+- **Warning**: due to stabilizing only a part of proc macro functionality in Rust 1.30, `#[trace]` can be used on `mod` only on nightly, and there is currently no way to use `#![trace]` as an outer attribute.
 
-- You can also use `#[trace]` on entire `impl`s or individual `impl` methods. See the `examples` folder for more details.
+  You can use `#[trace]` on `mod`s as well.
+  To apply `#[trace]` to all functions in the current `mod`, put `#![trace]` (note the `!`) at the top of the file.
+  When using `#[trace]` on `mod`s, the `depth` variable doesn't need to be defined (it's defined for you automatically).
+  Note that the `depth` variable isn't shared between `mod`s, so indentation won't be perfect when tracing functions in multiple `mod`s.
+
+- You can also use `#[trace]` on entire `impl`s or individual `impl` methods.
+  See the `examples` folder for more details.
 
 - If you use `#[trace]` on a `mod` or `impl` as well as on a method or function inside one of those structures, then only the outermost `#[trace]` is used.
 
@@ -62,15 +75,29 @@ I'm in bar!
 
 Trace takes a few optional arguments, described below:
 
-- `prefix_enter` - The prefix of the `println!` statement when a function is entered. Defaults to `[+]`.
+- `prefix_enter` -
+  The prefix of the `println!` statement when a function is entered.
+  Defaults to `[+]`.
 
-- `prefix_exit` - The prefix of the `println!` statement when a function is exited. Defaults to `[-]`.
+- `prefix_exit` -
+  The prefix of the `println!` statement when a function is exited.
+  Defaults to `[-]`.
 
-- `enable` - When applied to a `mod` or `impl`, `enable` takes a list of function names to print, not printing any functions that are not part of this list. All functions are enabled by default. When applied to an `impl` method or a function, `enable` takes a list of arguments to print, not printing any arguments that are not part of the list. All arguments are enabled by default.
+- `enable` -
+  When applied to a `mod` or `impl`, `enable` takes a list of function names to print, not printing any functions that are not part of this list.
+  All functions are enabled by default.
+  When applied to an `impl` method or a function, `enable` takes a list of arguments to print, not printing any arguments that are not part of the list.
+  All arguments are enabled by default.
 
-- `disable` - When applied to a `mod` or `impl`, `disable` takes a list of function names to not print, printing all other functions in the `mod` or `impl`. No functions are disabled by default. When applied to an `impl` method or a function, `disable` takes a list of arguments to not print, printing all other arguments. No arguments are disabled by default.
+- `disable` -
+  When applied to a `mod` or `impl`, `disable` takes a list of function names to not print, printing all other functions in the `mod` or `impl`.
+  No functions are disabled by default.
+  When applied to an `impl` method or a function, `disable` takes a list of arguments to not print, printing all other arguments.
+  No arguments are disabled by default.
 
-- `pause` - When given as an argument to `#[trace]`, execution is paused after each line of tracing output until enter is pressed. This allows you to trace through a program step by step.
+- `pause` -
+  When given as an argument to `#[trace]`, execution is paused after each line of tracing output until enter is pressed.
+  This allows you to trace through a program step by step.
 
 Note that `enable` and `disable` can not be used together, and doing so will result in an error.
 

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,7 +1,9 @@
-#![feature(custom_attribute, plugin)]
-#![plugin(trace)]
+extern crate trace;
 
-static mut depth: u32 = 0;
+use trace::trace;
+
+#[allow(non_upper_case_globals)]
+static mut depth: usize = 0;
 
 fn main() {
     foo(1, 2);

--- a/examples/example_enable_disable.rs
+++ b/examples/example_enable_disable.rs
@@ -1,7 +1,9 @@
-#![feature(custom_attribute, plugin)]
-#![plugin(trace)]
+extern crate trace;
 
-static mut depth: u32 = 0;
+use trace::trace;
+
+#[allow(non_upper_case_globals)]
+static mut depth: usize = 0;
 
 fn main() {
     let foo = Foo;

--- a/examples/example_impl.rs
+++ b/examples/example_impl.rs
@@ -1,7 +1,9 @@
-#![feature(custom_attribute, plugin)]
-#![plugin(trace)]
+extern crate trace;
 
-static mut depth: u32 = 0;
+use trace::trace;
+
+#[allow(non_upper_case_globals)]
+static mut depth: usize = 0;
 
 fn main() {
     let foo = Foo;

--- a/examples/example_impl_method.rs
+++ b/examples/example_impl_method.rs
@@ -1,7 +1,9 @@
-#![feature(custom_attribute, plugin)]
-#![plugin(trace)]
+extern crate trace;
 
-static mut depth: u32 = 0;
+use trace::trace;
+
+#[allow(non_upper_case_globals)]
+static mut depth: usize = 0;
 
 fn main() {
     let foo = Foo;

--- a/examples/example_mod.rs
+++ b/examples/example_mod.rs
@@ -1,19 +1,32 @@
-#![feature(custom_attribute, plugin)]
-#![plugin(trace)]
-#![trace]
+// error[E0658]: non-builtin inner attributes are unstable (see issue #54726)
+// error[E0658]: The attribute `trace` is currently unknown to the compiler and may have meaning added to it in the future (see issue #29642)
+//#![trace]
+
+#![feature(proc_macro_hygiene)]  // to use custom attributes on `mod`
+
+extern crate trace;
+
+use trace::trace;
+
+// error: an inner attribute is not permitted in this context
+// error[E0658]: non-builtin inner attributes are unstable (see issue #54726)
+//#![trace]
 
 fn main() {
-    foo();
-    let foo = Foo;
+    foo::foo();
+    let foo = foo::Foo;
     foo.bar();
 }
 
-fn foo() {
-    println!("I'm in foo!");
-}
+#[trace]
+mod foo{
+    pub(super) fn foo() {
+        println!("I'm in foo!");
+    }
 
-struct Foo;
-impl Foo {
-    fn bar(&self) {
+    pub(super) struct Foo;
+    impl Foo {
+        pub(super) fn bar(&self) {
+        }
     }
 }

--- a/examples/example_pause.rs
+++ b/examples/example_pause.rs
@@ -1,7 +1,9 @@
-#![feature(custom_attribute, plugin)]
-#![plugin(trace)]
+extern crate trace;
 
-static mut depth: u32 = 0;
+use trace::trace;
+
+#[allow(non_upper_case_globals)]
+static mut depth: usize = 0;
 
 fn main() {
     foo(1);

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,247 @@
+use std::collections::HashSet;
+
+use syn::{
+    self,
+    spanned::Spanned,
+};
+
+
+pub(crate) struct Args {
+    pub(crate) prefix_enter: String,
+    pub(crate) prefix_exit: String,
+    pub(crate) filter: Filter,
+    pub(crate) pause: bool,
+}
+
+pub(crate) enum Filter {
+    None,
+    Enable(HashSet<proc_macro2::Ident>),
+    Disable(HashSet<proc_macro2::Ident>),
+}
+
+const DEFAULT_PREFIX_ENTER: &str = "[+]";
+const DEFAULT_PREFIX_EXIT: &str = "[-]";
+const DEFAULT_PAUSE: bool = false;
+
+impl Args {
+    pub(crate) fn from_raw_args(raw_args: syn::AttributeArgs) -> Result<Self, Vec<syn::parse::Error>> {
+        // Different types of arguments accepted by `#[trace]`;
+        // spans are needed for friendly error reporting of duplicate arguments
+        enum Arg {
+            PrefixEnter(proc_macro2::Span, String),
+            PrefixExit(proc_macro2::Span, String),
+            Enable(proc_macro2::Span, HashSet<proc_macro2::Ident>),
+            Disable(proc_macro2::Span, HashSet<proc_macro2::Ident>),
+            Pause(proc_macro2::Span, bool),
+        }
+
+        // Parse arguments
+        let args_res = raw_args.into_iter().map(|nested_meta| match nested_meta {
+            syn::NestedMeta::Meta(ref meta) => {
+                enum ArgName {
+                    PrefixEnter,
+                    PrefixExit,
+                    Enable,
+                    Disable,
+                    Pause,
+                }
+
+                let ident = meta.name();
+                let arg_name = match ident.to_string().as_str() {
+                    "prefix_enter" => ArgName::PrefixEnter,
+                    "prefix_exit"  => ArgName::PrefixExit,
+                    "enable"       => ArgName::Enable,
+                    "disable"      => ArgName::Disable,
+                    "pause"        => ArgName::Pause,
+                    _ => return Err(vec![syn::parse::Error::new(
+                        ident.span(),
+                        format_args!("unknown attribute argument `{}`", ident),
+                    )]),
+                };
+
+                let prefix_enter_type_error = || vec![
+                    syn::parse::Error::new(ident.span(), "`prefix_enter` requires a string value")
+                ];
+                let prefix_exit_type_error = || vec![
+                    syn::parse::Error::new(ident.span(), "`prefix_exit` requires a string value")
+                ];
+                let enable_type_error = || vec![
+                    syn::parse::Error::new(ident.span(), "`enable` requires a list of meta words")
+                ];
+                let disable_type_error = || vec![
+                    syn::parse::Error::new(ident.span(), "`disable` requires a list of meta words")
+                ];
+                let pause_type_error = || vec![
+                    syn::parse::Error::new(ident.span(), "`pause` must be a meta word")
+                ];
+
+                match *meta {
+                    syn::Meta::Word(_) => match arg_name {
+                        ArgName::Pause => Ok(Arg::Pause(meta.span(), true)),
+
+                        ArgName::PrefixEnter => Err(prefix_enter_type_error()),
+                        ArgName::PrefixExit  => Err(prefix_exit_type_error()),
+                        ArgName::Enable      => Err(enable_type_error()),
+                        ArgName::Disable     => Err(disable_type_error()),
+                    },
+                    syn::Meta::List(syn::MetaList { ref nested, .. }) => match arg_name {
+                        ArgName::Enable => {
+                            let mut idents = HashSet::new();
+                            let mut other_nested_meta_errors = Vec::new();
+
+                            nested.iter().for_each(|nested_meta| match *nested_meta {
+                                syn::NestedMeta::Meta(syn::Meta::Word(ref word)) => {
+                                    idents.insert(word.clone());
+                                },
+                                _ => other_nested_meta_errors.push(syn::parse::Error::new(
+                                    nested_meta.span(),
+                                    "`enable` must contain words only",
+                                )),
+                            });
+
+                            if other_nested_meta_errors.is_empty() {
+                                Ok(Arg::Enable(meta.span(), idents))
+                            } else {
+                                Err(other_nested_meta_errors)
+                            }
+                        },
+                        ArgName::Disable => {
+                            let mut idents = HashSet::new();
+                            let mut other_nested_meta_errors = Vec::new();
+
+                            nested.iter().for_each(|nested_meta| match *nested_meta {
+                                syn::NestedMeta::Meta(syn::Meta::Word(ref word)) => {
+                                    idents.insert(word.clone());
+                                },
+                                _ => other_nested_meta_errors.push(syn::parse::Error::new(
+                                    nested_meta.span(),
+                                    "`disable` must contain words only",
+                                )),
+                            });
+
+                            if other_nested_meta_errors.is_empty() {
+                                Ok(Arg::Disable(meta.span(), idents))
+                            } else {
+                                Err(other_nested_meta_errors)
+                            }
+                        },
+
+                        ArgName::PrefixEnter => Err(prefix_enter_type_error()),
+                        ArgName::PrefixExit  => Err(prefix_exit_type_error()),
+                        ArgName::Pause       => Err(pause_type_error()),
+                    },
+                    syn::Meta::NameValue(syn::MetaNameValue { ref lit, .. }) => match arg_name {
+                        ArgName::PrefixEnter => match *lit {
+                            syn::Lit::Str(ref lit_str) => {
+                                Ok(Arg::PrefixEnter(meta.span(), lit_str.value()))
+                            },
+                            _ => Err(vec![syn::parse::Error::new(
+                                lit.span(),
+                                "`prefix_enter` must have a string value",
+                            )]),
+                        },
+                        ArgName::PrefixExit => match *lit {
+                            syn::Lit::Str(ref lit_str) => {
+                                Ok(Arg::PrefixExit(meta.span(), lit_str.value()))
+                            },
+                            _ => Err(vec![syn::parse::Error::new(
+                                lit.span(),
+                                "`prefix_exit` must have a string value",
+                            )]),
+                        },
+
+                        ArgName::Enable  => Err(enable_type_error()),
+                        ArgName::Disable => Err(disable_type_error()),
+                        ArgName::Pause   => Err(pause_type_error()),
+                    },
+                }
+            },
+            syn::NestedMeta::Literal(_) => {
+                Err(vec![syn::parse::Error::new(nested_meta.span(), "literal attribute not allowed")])
+            },
+        });
+
+        let mut prefix_enter_args = vec![];
+        let mut prefix_exit_args = vec![];
+        let mut enable_args = vec![];
+        let mut disable_args = vec![];
+        let mut pause_args = vec![];
+        let mut errors = vec![];
+
+        // Group arguments of the same type and errors
+        for arg_res in args_res {
+            match arg_res {
+                Ok(arg) => match arg {
+                    Arg::PrefixEnter(span, s)  => prefix_enter_args.push((span, s)),
+                    Arg::PrefixExit(span, s)   => prefix_exit_args.push((span, s)),
+                    Arg::Enable(span, idents)  => enable_args.push((span, idents)),
+                    Arg::Disable(span, idents) => disable_args.push((span, idents)),
+                    Arg::Pause(span, b)        => pause_args.push((span, b)),
+                },
+                Err(es) => errors.extend(es),
+            }
+        }
+
+        // Report duplicates
+        if prefix_enter_args.len() >= 2 {
+            errors.extend(prefix_enter_args.iter().map(|(span, _)| {
+                syn::parse::Error::new(*span, "duplicate `prefix_enter`")
+            }));
+        }
+        if prefix_exit_args.len() >= 2 {
+            errors.extend(prefix_exit_args.iter().map(|(span, _)| {
+                syn::parse::Error::new(*span, "duplicate `prefix_exit`")
+            }));
+        }
+        if enable_args.len() >= 2 {
+            errors.extend(enable_args.iter().map(|(span, _)| {
+                syn::parse::Error::new(*span, "duplicate `enable`")
+            }));
+        }
+        if disable_args.len() >= 2 {
+            errors.extend(disable_args.iter().map(|(span, _)| {
+                syn::parse::Error::new(*span, "duplicate `disable`")
+            }));
+        }
+        if pause_args.len() >= 2 {
+            errors.extend(pause_args.iter().map(|(span, _)| {
+                syn::parse::Error::new(*span, "duplicate `pause`")
+            }));
+        }
+
+        // Report the presence of mutually exclusive arguments
+        if enable_args.len() == 1 && disable_args.len() == 1 {
+            errors.push(syn::parse::Error::new(
+                enable_args[0].0,
+                "cannot have both `enable` and `disable`",
+            ));
+            errors.push(syn::parse::Error::new(
+                disable_args[0].0,
+                "cannot have both `enable` and `disable`",
+            ));
+        }
+
+        if errors.is_empty() {
+            macro_rules! first_no_span {
+                ($iterable:expr) => { $iterable.into_iter().next().map(|(_, elem)| elem) };
+            }
+
+            let prefix_enter = first_no_span!(prefix_enter_args)
+                .unwrap_or_else(|| DEFAULT_PREFIX_ENTER.to_owned());
+            let prefix_exit = first_no_span!(prefix_exit_args)
+                .unwrap_or_else(|| DEFAULT_PREFIX_EXIT.to_owned());
+            let filter = match (first_no_span!(enable_args), first_no_span!(disable_args)) {
+                (None, None) => Filter::None,
+                (Some(idents), None) => Filter::Enable(idents),
+                (None, Some(idents)) => Filter::Disable(idents),
+                (Some(_), Some(_)) => unreachable!(),
+            };
+            let pause = first_no_span!(pause_args)
+                .unwrap_or(DEFAULT_PAUSE);
+
+            Ok(Self { prefix_enter, prefix_exit, filter, pause })
+        } else {
+            Err(errors)
+        }
+    }
+}


### PR DESCRIPTION
As of the latest stable Rust 1.30, there is no need to depend on the unstable plugin interface to accomplish goals of this crate. Consequently, the requirement to chase the latest nightly has also been obsoleted.

List of functionality changes:
* Use `extern crate trace;` + `use trace::trace;` instead of `#![feature(custom_attribute, plugin)]` + `![plugin(trace)]`.
* Using `#![trace]` (as an inner attribute) is not stable yet --- `example_mod` has been changed to use `#[trace]` as an outer attribute instead.
* Traces for functions and methods now print "arg_name = value" instead of "arg_name: value" for arguments (in my opinion, they look more readable).