### PR TITLE
Updated to compile on 1.33.0 nightly; now on edition 2018; also cleanups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "trace"
 version = "0.1.4"
+edition = "2018"
 authors = ["Gulshan Singh <gsingh2011@gmail.com>"]
 repository = "https://github.com/gsingh93/trace"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trace"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2018"
 authors = ["Gulshan Singh <gsingh2011@gmail.com>"]
 repository = "https://github.com/gsingh93/trace"

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -13,7 +13,7 @@ fn foo(a: i32, b: i32) {
     bar((a, b));
 }
 
-#[trace(prefix_enter="[ENTER]", prefix_exit="[EXIT]")]
+#[trace(prefix_enter = "[ENTER]", prefix_exit = "[EXIT]")]
 fn bar((a, b): (i32, i32)) -> i32 {
     println!("I'm in bar!");
     if a == 1 {

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,7 +1,7 @@
 #![feature(custom_attribute, plugin)]
 #![plugin(trace)]
 
-static mut depth: u32 = 0;
+static mut DEPTH: u32 = 0;
 
 fn main() {
     foo(1, 2);

--- a/examples/example_enable_disable.rs
+++ b/examples/example_enable_disable.rs
@@ -1,7 +1,7 @@
 #![feature(custom_attribute, plugin)]
 #![plugin(trace)]
 
-static mut depth: u32 = 0;
+static mut DEPTH: u32 = 0;
 
 fn main() {
     let foo = Foo;

--- a/examples/example_impl.rs
+++ b/examples/example_impl.rs
@@ -1,7 +1,7 @@
 #![feature(custom_attribute, plugin)]
 #![plugin(trace)]
 
-static mut depth: u32 = 0;
+static mut DEPTH: u32 = 0;
 
 fn main() {
     let foo = Foo;

--- a/examples/example_impl_method.rs
+++ b/examples/example_impl_method.rs
@@ -1,7 +1,7 @@
 #![feature(custom_attribute, plugin)]
 #![plugin(trace)]
 
-static mut depth: u32 = 0;
+static mut DEPTH: u32 = 0;
 
 fn main() {
     let foo = Foo;

--- a/examples/example_mod.rs
+++ b/examples/example_mod.rs
@@ -14,6 +14,5 @@ fn foo() {
 
 struct Foo;
 impl Foo {
-    fn bar(&self) {
-    }
+    fn bar(&self) {}
 }

--- a/examples/example_pause.rs
+++ b/examples/example_pause.rs
@@ -1,7 +1,7 @@
 #![feature(custom_attribute, plugin)]
 #![plugin(trace)]
 
-static mut depth: u32 = 0;
+static mut DEPTH: u32 = 0;
 
 fn main() {
     foo(1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,7 +279,7 @@ fn expand_mod(cx: &mut ExtCtxt, m: &ast::Mod, options: Options) -> Vec<P<Item>> 
             }
             Static(_, ref mut_, ref expr) => {
                 let name = &i.ident.name.as_str();
-                if *name == Symbol::intern("depth").as_str() {
+                if *name == Symbol::intern("DEPTH").as_str() {
                     depth_span = Some(i.span);
                     if let &Mutable = mut_ {
                         if let Lit(ref lit) = expr.node {
@@ -319,12 +319,12 @@ fn expand_mod(cx: &mut ExtCtxt, m: &ast::Mod, options: Options) -> Vec<P<Item>> 
         if !depth_correct {
             cx.span_err(
                 sp,
-                "A static variable with the name `depth` was found, but either the \
+                "A static variable with the name `DEPTH` was found, but either the \
                  mutability, the type, or the inital value are incorrect",
             );
         }
     } else {
-        let depth_ident = Ident::with_empty_ctxt(Symbol::intern("depth"));
+        let depth_ident = Ident::with_empty_ctxt(Symbol::intern("DEPTH"));
         let u32_ident = Ident::with_empty_ctxt(Symbol::intern("u32"));
         let ty = cx.ty_path(cx.path(source_map::DUMMY_SP, vec![u32_ident]));
         let item_ = cx.item_static(
@@ -460,27 +460,27 @@ fn new_block(
     let pause = options.pause;
 
     let new_block = quote_expr!(cx,
-    unsafe {
-        let mut s = String::new();
-        (0..depth).map(|_| s.push(' ')).count();
-        let args = format!($arg_fmt_str, $args);
-        println!("{}{} Entering {}({})", s, $prefix_enter, $name, args);
-        if $pause {
-            use std::io::{BufRead, stdin};
-            let stdin = stdin();
-            stdin.lock().lines().next();
-        }
-        depth += 1;
-        let mut __trace_closure = move || $block;
-        let __trace_result = __trace_closure();
-        depth -= 1;
-        println!("{}{} Exiting {} = {:?}", s, $prefix_exit, $name, __trace_result);
-        if $pause {
-            use std::io::{BufRead, stdin};
-            let stdin = stdin();
-            stdin.lock().lines().next();
-        }
-        __trace_result
+        unsafe {
+            let mut s = String::new();
+            (0..DEPTH).map(|_| s.push(' ')).count();
+            let args = format!($arg_fmt_str, $args);
+            println!("{}{} Entering {}({})", s, $prefix_enter, $name, args);
+            if $pause {
+                use std::io::{BufRead, stdin};
+                let stdin = stdin();
+                stdin.lock().lines().next();
+            }
+            DEPTH += 1;
+            let mut __trace_closure = move || $block;
+            let __trace_result = __trace_closure();
+            DEPTH -= 1;
+            println!("{}{} Exiting {} = {:?}", s, $prefix_exit, $name, __trace_result);
+            if $pause {
+                use std::io::{BufRead, stdin};
+                let stdin = stdin();
+                stdin.lock().lines().next();
+            }
+            __trace_result
     });
     cx.block_expr(new_block)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,38 +1,44 @@
 #![feature(quote, plugin_registrar, rustc_private)]
 
-extern crate syntax;
 extern crate rustc_plugin;
+extern crate syntax;
 
 use std::collections::HashSet;
 
 use rustc_plugin::Registry;
 
-use syntax::ptr::P;
-use syntax::ast::{self, Item, ItemKind, MetaItem, Block, Ident, FnDecl, ImplItem, ImplItemKind,
-                  PatKind, NestedMetaItemKind};
 use syntax::ast::ExprKind::Lit;
-use syntax::ast::ItemKind::{Fn, Mod, Impl, Static};
-use syntax::ast::Mutability::Mutable;
+use syntax::ast::ItemKind::{Fn, Impl, Mod, Static};
+use syntax::ast::LitKind::{Int, Str};
 use syntax::ast::MetaItemKind::{List, NameValue, Word};
-use syntax::ast::LitKind::{Str, Int};
-use syntax::source_map::{self, Span};
-use syntax::ext::base::{ExtCtxt, Annotatable};
+use syntax::ast::Mutability::Mutable;
+use syntax::ast::{
+    self, Block, FnDecl, Ident, ImplItem, ImplItemKind, Item, ItemKind, MetaItem,
+    NestedMetaItemKind, PatKind,
+};
 use syntax::ext::base::SyntaxExtension::MultiModifier;
+use syntax::ext::base::{Annotatable, ExtCtxt};
 use syntax::ext::build::AstBuilder;
 use syntax::parse::token;
-use syntax::tokenstream::TokenTree;
+use syntax::ptr::P;
+use syntax::source_map::{self, Span};
 use syntax::symbol::Symbol;
+use syntax::tokenstream::TokenTree;
 
 #[plugin_registrar]
 pub fn registrar(reg: &mut Registry) {
-    reg.register_syntax_extension(Symbol::intern("trace"), MultiModifier(Box::new(trace_expand)));
+    reg.register_syntax_extension(
+        Symbol::intern("trace"),
+        MultiModifier(Box::new(trace_expand)),
+    );
 }
 
-fn trace_expand(cx: &mut ExtCtxt,
-                sp: Span,
-                meta: &MetaItem,
-                annotatable: Annotatable)
-                -> Annotatable {
+fn trace_expand(
+    cx: &mut ExtCtxt,
+    sp: Span,
+    meta: &MetaItem,
+    annotatable: Annotatable,
+) -> Annotatable {
     let options = get_options(cx, meta);
     match annotatable {
         Annotatable::Item(item) => {
@@ -40,31 +46,48 @@ fn trace_expand(cx: &mut ExtCtxt,
                 Fn(..) => {
                     let new_item = expand_function(cx, options, &item, true);
                     cx.item(item.span, item.ident, item.attrs.clone(), new_item)
-                        .map(|mut it| { it.vis = item.vis.clone(); it })
+                        .map(|mut it| {
+                            it.vis = item.vis.clone();
+                            it
+                        })
                 }
                 Mod(ref m) => {
                     let new_items = expand_mod(cx, m, options);
-                    cx.item(item.span,
-                            item.ident,
-                            item.attrs.clone(),
-                            Mod(ast::Mod {
-                                inner: m.inner,
-                                items: new_items,
-                                inline: m.inline,
-                            }))
+                    cx.item(
+                        item.span,
+                        item.ident,
+                        item.attrs.clone(),
+                        Mod(ast::Mod {
+                            inner: m.inner,
+                            items: new_items,
+                            inline: m.inline,
+                        }),
+                    )
                 }
-                Impl(safety, polarity, defaultness, ref generics, ref traitref, ref ty, ref items) => {
+                Impl(
+                    safety,
+                    polarity,
+                    defaultness,
+                    ref generics,
+                    ref traitref,
+                    ref ty,
+                    ref items,
+                ) => {
                     let new_items = expand_impl(cx, &*items, options);
-                    cx.item(item.span,
-                            item.ident,
-                            item.attrs.clone(),
-                            Impl(safety,
-                                 polarity,
-                                 defaultness,
-                                 generics.clone(),
-                                 traitref.clone(),
-                                 ty.clone(),
-                                 new_items))
+                    cx.item(
+                        item.span,
+                        item.ident,
+                        item.attrs.clone(),
+                        Impl(
+                            safety,
+                            polarity,
+                            defaultness,
+                            generics.clone(),
+                            traitref.clone(),
+                            ty.clone(),
+                            new_items,
+                        ),
+                    )
                 }
                 _ => {
                     cx.span_err(sp, "trace is only permissible on functions, mods, or impls");
@@ -129,8 +152,7 @@ fn get_options(cx: &mut ExtCtxt, meta: &MetaItem) -> Options {
                 Word => {
                     v.insert(item.name().to_string());
                 }
-                List(_) |
-                NameValue(_) => {
+                List(_) | NameValue(_) => {
                     cx.span_warn(item.span, &format!("Invalid option {}", item.name()))
                 }
             }
@@ -157,7 +179,8 @@ fn get_options(cx: &mut ExtCtxt, meta: &MetaItem) -> Options {
                         }
                     }
                     List(ref list) => {
-                        let list: Vec<_> = list.iter()
+                        let list: Vec<_> = list
+                            .iter()
                             .filter_map(|x| {
                                 if let NestedMetaItemKind::MetaItem(ref mi) = x.node {
                                     Some(&(*mi))
@@ -186,8 +209,10 @@ fn get_options(cx: &mut ExtCtxt, meta: &MetaItem) -> Options {
         }
     }
     if options.enable.is_some() && options.disable.is_some() {
-        cx.span_err(meta.span,
-                    "Cannot use both enable and disable options with trace");
+        cx.span_err(
+            meta.span,
+            "Cannot use both enable and disable options with trace",
+        );
     }
     options
 }
@@ -207,11 +232,12 @@ fn expand_impl(cx: &mut ExtCtxt, items: &[ImplItem], options: Options) -> Vec<Im
     new_items
 }
 
-fn expand_impl_method(cx: &mut ExtCtxt,
-                      options: Options,
-                      item: &ImplItem,
-                      direct: bool)
-                      -> ImplItemKind {
+fn expand_impl_method(
+    cx: &mut ExtCtxt,
+    options: Options,
+    item: &ImplItem,
+    direct: bool,
+) -> ImplItemKind {
     let name = &*item.ident.name.as_str();
 
     // If the attribute is not directly on this method, we filter by function names
@@ -269,16 +295,20 @@ fn expand_mod(cx: &mut ExtCtxt, m: &ast::Mod, options: Options) -> Vec<P<Item>> 
             }
             Impl(safety, polarity, defaultness, ref generics, ref traitref, ref ty, ref items) => {
                 let new_impl_items = expand_impl(cx, &**items, options.clone());
-                new_items.push(cx.item(i.span,
-                                       i.ident,
-                                       i.attrs.clone(),
-                                       Impl(safety,
-                                            polarity,
-                                            defaultness,
-                                            generics.clone(),
-                                            traitref.clone(),
-                                            ty.clone(),
-                                            new_impl_items)));
+                new_items.push(cx.item(
+                    i.span,
+                    i.ident,
+                    i.attrs.clone(),
+                    Impl(
+                        safety,
+                        polarity,
+                        defaultness,
+                        generics.clone(),
+                        traitref.clone(),
+                        ty.clone(),
+                        new_impl_items,
+                    ),
+                ));
             }
             _ => {
                 new_items.push((*i).clone());
@@ -287,19 +317,23 @@ fn expand_mod(cx: &mut ExtCtxt, m: &ast::Mod, options: Options) -> Vec<P<Item>> 
     }
     if let Some(sp) = depth_span {
         if !depth_correct {
-            cx.span_err(sp,
-                        "A static variable with the name `depth` was found, but either the \
-                         mutability, the type, or the inital value are incorrect");
+            cx.span_err(
+                sp,
+                "A static variable with the name `depth` was found, but either the \
+                 mutability, the type, or the inital value are incorrect",
+            );
         }
     } else {
         let depth_ident = Ident::with_empty_ctxt(Symbol::intern("depth"));
         let u32_ident = Ident::with_empty_ctxt(Symbol::intern("u32"));
         let ty = cx.ty_path(cx.path(source_map::DUMMY_SP, vec![u32_ident]));
-        let item_ = cx.item_static(source_map::DUMMY_SP,
-                                   depth_ident,
-                                   ty,
-                                   Mutable,
-                                   cx.expr_u32(source_map::DUMMY_SP, 0));
+        let item_ = cx.item_static(
+            source_map::DUMMY_SP,
+            depth_ident,
+            ty,
+            Mutable,
+            cx.expr_u32(source_map::DUMMY_SP, 0),
+        );
         new_items.push(item_);
     }
 
@@ -312,8 +346,7 @@ fn expand_function(cx: &mut ExtCtxt, options: Options, item: &P<Item>, direct: b
     // If the attribute is not directly on this method, we filter by function names
     if !direct {
         match (&options.enable, &options.disable) {
-            (&Some(ref s), &None) |
-            (&None, &Some(ref s)) => {
+            (&Some(ref s), &None) | (&None, &Some(ref s)) => {
                 if !s.contains(*name) {
                     return item.node.clone();
                 }
@@ -326,10 +359,7 @@ fn expand_function(cx: &mut ExtCtxt, options: Options, item: &P<Item>, direct: b
     if let Fn(ref decl, ref header, ref generics, ref block) = item.node {
         let idents = arg_idents(cx, &**decl);
         let new_block = new_block(cx, options, name, block.clone(), idents, direct);
-        Fn(decl.clone(),
-           header.clone(),
-           generics.clone(),
-           new_block)
+        Fn(decl.clone(), header.clone(), generics.clone(), new_block)
     } else {
         panic!("Expected a function")
     }
@@ -338,19 +368,18 @@ fn expand_function(cx: &mut ExtCtxt, options: Options, item: &P<Item>, direct: b
 fn arg_idents(cx: &mut ExtCtxt, decl: &FnDecl) -> Vec<Ident> {
     fn extract_idents(cx: &mut ExtCtxt, pat: &ast::PatKind, idents: &mut Vec<Ident>) {
         match *pat {
-            PatKind::Paren(..) |
-            PatKind::Wild |
-            PatKind::TupleStruct(_, _, None) |
-            PatKind::Lit(_) |
-            PatKind::Range(..) |
-            PatKind::Path(..) => (),
+            PatKind::Paren(..)
+            | PatKind::Wild
+            | PatKind::TupleStruct(_, _, None)
+            | PatKind::Lit(_)
+            | PatKind::Range(..)
+            | PatKind::Path(..) => (),
             PatKind::Ident(_, sp, _) => {
                 if &*sp.name.as_str() != "self" {
                     idents.push(sp);
                 }
             }
-            PatKind::TupleStruct(_, ref v, _) |
-            PatKind::Tuple(ref v, _) => {
+            PatKind::TupleStruct(_, ref v, _) | PatKind::Tuple(ref v, _) => {
                 for p in v {
                     extract_idents(cx, &p.node, idents);
                 }
@@ -371,8 +400,7 @@ fn arg_idents(cx: &mut ExtCtxt, decl: &FnDecl) -> Vec<Ident> {
                     extract_idents(cx, &p.node, idents);
                 }
             }
-            PatKind::Box(ref p) |
-            PatKind::Ref(ref p, _) => extract_idents(cx, &p.node, idents),
+            PatKind::Box(ref p) | PatKind::Ref(ref p, _) => extract_idents(cx, &p.node, idents),
             PatKind::Mac(ref m) => {
                 let sp = m.node.path.span;
                 cx.span_warn(sp, "trace ignores pattern macros in function arguments");
@@ -386,22 +414,25 @@ fn arg_idents(cx: &mut ExtCtxt, decl: &FnDecl) -> Vec<Ident> {
     idents
 }
 
-fn new_block(cx: &mut ExtCtxt,
-             options: Options,
-             name: &str,
-             block: P<Block>,
-             idents: Vec<Ident>,
-             direct: bool)
-             -> P<Block> {
+fn new_block(
+    cx: &mut ExtCtxt,
+    options: Options,
+    name: &str,
+    block: P<Block>,
+    idents: Vec<Ident>,
+    direct: bool,
+) -> P<Block> {
     // If the attribute is on this method, we filter the arguments
     let idents = if direct {
         match (&options.enable, &options.disable) {
-            (&Some(ref s), &None) => {
-                idents.into_iter().filter(|x| s.contains(&*x.name.as_str())).collect()
-            }
-            (&None, &Some(ref s)) => {
-                idents.into_iter().filter(|x| !s.contains(&*x.name.as_str())).collect()
-            }
+            (&Some(ref s), &None) => idents
+                .into_iter()
+                .filter(|x| s.contains(&*x.name.as_str()))
+                .collect(),
+            (&None, &Some(ref s)) => idents
+                .into_iter()
+                .filter(|x| !s.contains(&*x.name.as_str()))
+                .collect(),
             (&Some(_), &Some(_)) => unreachable!(),
             _ => idents,
         }
@@ -409,7 +440,8 @@ fn new_block(cx: &mut ExtCtxt,
         idents
     };
 
-    let args: Vec<TokenTree> = idents.iter()
+    let args: Vec<TokenTree> = idents
+        .iter()
         .map(|&ident| vec![token::Ident(ident.clone(), false)])
         .collect::<Vec<_>>()
         .join(&token::Comma)


### PR DESCRIPTION
The commit messages give an okay amount of context. This should still work as expected on Rust nightly. The only iffy thing is whether you think bumping to version 0.2 is necessary. I say "yes" only because of the Rust 2018 update.