### PR TITLE
Add flag to pretty print trace return value

### DIFF
--- a/examples/example_pretty.rs
+++ b/examples/example_pretty.rs
@@ -1,0 +1,17 @@
+extern crate trace;
+
+use trace::trace;
+
+trace::init_depth_var!();
+
+fn main() {
+    foo(Foo("Foo".to_string()));
+}
+
+#[derive(Debug)]
+struct Foo(String);
+
+#[trace(pretty)]
+fn foo(a: Foo) -> Foo {
+    a
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,10 +230,11 @@ fn construct_traced_block(
         .collect::<Vec<_>>()
         .join(", ");
 
+    let pretty = if args.pretty { "#" } else { "" };
     let entering_format =
         format!("{{:depth$}}{} Entering {}({})", args.prefix_enter, ident, arg_idents_format);
     let exiting_format =
-        format!("{{:depth$}}{} Exiting {} = {{:?}}", args.prefix_exit, ident);
+        format!("{{:depth$}}{} Exiting {} = {{:{}?}}", args.prefix_exit, ident, pretty);
 
     let pause_stmt = if args.pause {
         quote! {{


### PR DESCRIPTION
Add a flag `pretty` to the trace macro that effectively adds the `#` flag to the format, see https://doc.rust-lang.org/std/fmt/index.html#sign/#/0