### PR TITLE
Allow use of log::trace! instead of println!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,7 @@ proc-macro = true
 proc-macro2 = "0.4.20"
 quote = "0.6.8"
 syn = { version = "0.15.22", features = ["full"] }
+
+[dev-dependencies]
+log = "0.4.0"
+env_logger = "0.6.2"

--- a/examples/example_logging.rs
+++ b/examples/example_logging.rs
@@ -1,0 +1,17 @@
+extern crate env_logger;
+extern crate log;
+extern crate trace;
+
+use trace::trace;
+
+trace::init_depth_var!();
+
+fn main() {
+    env_logger::init();
+    foo(1, 2);
+}
+
+#[trace(logging)]
+fn foo(a: i32, b: i32) {
+    println!("I'm in foo!");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,14 +246,20 @@ fn construct_traced_block(
         quote!()
     };
 
+    let printer = if args.logging {
+        quote! { log::trace! }
+    } else {
+        quote! { println! }
+    };
+
     parse_quote! {{
-        println!(#entering_format, "", #(#arg_idents,)* depth = DEPTH.with(|d| d.get()));
+        #printer(#entering_format, "", #(#arg_idents,)* depth = DEPTH.with(|d| d.get()));
         #pause_stmt
         DEPTH.with(|d| d.set(d.get() + 1));
         let mut fn_closure = move || #original_block;
         let fn_return_value = fn_closure();
         DEPTH.with(|d| d.set(d.get() - 1));
-        println!(#exiting_format, "", fn_return_value, depth = DEPTH.with(|d| d.get()));
+        #printer(#exiting_format, "", fn_return_value, depth = DEPTH.with(|d| d.get()));
         #pause_stmt
         fn_return_value
     }}


### PR DESCRIPTION
This lets you do ` #[trace(logging)]` to invoke entry/exit trace with `log::trace!` instead of `println!`. Fixes #15.