### PR TITLE
Fix minimal-versions test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ quote = "0.6.8"
 syn = { version = "0.15.22", features = ["full"] }
 
 [dev-dependencies]
-log = "0.4.0"
+log = "0.4.8"
 env_logger = "0.6.2"


### PR DESCRIPTION
The change needed was in log 0.4.4 (https://github.com/rust-lang-nursery/log/blob/master/CHANGELOG.md#improved-3) but there are a few other macro-related fixes so I went for 0.4.8 for safety.