### PR TITLE
Enable use of await inside items marked with #[trace]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,5 @@ syn = { version = "1.0", features = ["full"] }
 log = "0.4.8"
 env_logger = "0.8"
 gag = "0.1.10"
+async-trait = { version = "0.1.56" }
+async-std = { version = "1.12.0", features = ["attributes"]}

--- a/examples/example_async.rs
+++ b/examples/example_async.rs
@@ -52,4 +52,8 @@ fn main() {
 }
 
 #[cfg(test)]
+#[macro_use]
+mod trace_test;
+
+#[cfg(test)]
 trace_test!(test_async, main());

--- a/examples/example_async.rs
+++ b/examples/example_async.rs
@@ -1,0 +1,55 @@
+use async_std::task;
+use trace::trace;
+
+trace::init_depth_var!();
+
+#[trace]
+async fn squared(x: i32) -> i32 {
+    x * x
+}
+
+#[async_trait::async_trait]
+trait Log {
+    async fn log(&self, message: &str) -> String;
+}
+
+#[async_trait::async_trait]
+trait Cubed {
+    async fn cubed(x: i32) -> i32;
+}
+
+struct Logger {
+    level: String,
+}
+
+struct Math {}
+
+#[trace(prefix_enter = "BEEF")]
+#[async_trait::async_trait]
+impl Log for Logger {
+    async fn log(&self, message: &str) -> String {
+        format!("[{}] {message}", self.level)
+    }
+}
+
+#[trace]
+#[async_trait::async_trait]
+impl Cubed for Math {
+    async fn cubed(x: i32) -> i32 {
+        squared(squared(x).await).await
+    }
+}
+
+fn main() {
+    task::block_on(async {
+        squared(64).await;
+        let logger = Logger {
+            level: "DEBUG".to_string(),
+        };
+        logger.log("something happened").await;
+        Math::cubed(32).await;
+    });
+}
+
+#[cfg(test)]
+trace_test!(test_async, main());

--- a/examples/example_async.rs
+++ b/examples/example_async.rs
@@ -24,7 +24,7 @@ struct Logger {
 
 struct Math {}
 
-#[trace(prefix_enter = "BEEF")]
+#[trace(prefix_enter = "INFO")]
 #[async_trait::async_trait]
 impl Log for Logger {
     async fn log(&self, message: &str) -> String {

--- a/examples/example_async.rs
+++ b/examples/example_async.rs
@@ -24,7 +24,7 @@ struct Logger {
 
 struct Math {}
 
-#[trace(prefix_enter = "INFO")]
+#[trace]
 #[async_trait::async_trait]
 impl Log for Logger {
     async fn log(&self, message: &str) -> String {

--- a/examples/expected_test_outputs/test_async.expected
+++ b/examples/expected_test_outputs/test_async.expected
@@ -1,0 +1,10 @@
+[+] Entering squared(x = 64)
+[-] Exiting squared = 4096
+[+] Entering log(message = "something happened")
+[-] Exiting log = "[DEBUG] something happened"
+[+] Entering cubed(x = 32)
+ [+] Entering squared(x = 32)
+ [-] Exiting squared = 1024
+ [+] Entering squared(x = 1024)
+ [-] Exiting squared = 1048576
+[-] Exiting cubed = 1048576

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,8 +356,7 @@ fn construct_traced_block(
         #printer(#entering_format, "", #(#arg_idents,)* depth = DEPTH.with(|d| d.get()));
         #pause_stmt
         DEPTH.with(|d| d.set(d.get() + 1));
-        let mut fn_closure = move || #original_block;
-        let fn_return_value = fn_closure();
+        let fn_return_value = #original_block;
         DEPTH.with(|d| d.set(d.get() - 1));
         #printer(#exiting_format, "", fn_return_value, depth = DEPTH.with(|d| d.get()));
         #pause_stmt


### PR DESCRIPTION
Original implementation wrapped the input `Block` in a closure to call it, but I think this is superfluous and prevents use of `#[trace]` for `async` impls